### PR TITLE
Anyone can install this gem

### DIFF
--- a/factory_strategist.gemspec
+++ b/factory_strategist.gemspec
@@ -15,8 +15,6 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
   spec.required_ruby_version = ">= 3.0.0"
 
-  spec.metadata["allowed_push_host"] = "TODO: Set to 'https://mygemserver.com'"
-
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/neko314/factory_strategist"
   spec.metadata["changelog_uri"] = "https://github.com/neko314/factory_strategist/blob/main/CHANGELOG.md"


### PR DESCRIPTION
According to https://guides.rubygems.org/publishing/#serving-your-own-gems, `metadata['allowed_push_host']` is needed when I want to publish private gem, but this is public.