### PR TITLE
Change env name for enabling this gem

### DIFF
--- a/lib/factory_strategist.rb
+++ b/lib/factory_strategist.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
 require_relative "factory_strategist/version"
-require_relative "factory_strategist/configure" if ENV["FATORYSTRATEGIST"]
+require_relative "factory_strategist/configure" if ENV["FACTORY_STRATEGIST"]


### PR DESCRIPTION
I think it has typo, and I believe with underscore it looks much nicer.